### PR TITLE
feat: remove subscription when createStore is called

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Qwiddle
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "svelte-tezos",
 	"version": "1.0.2",
+	"license": "MIT",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "svelte-tezos",
-	"version": "0.0.1",
+	"version": "1.0.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",

--- a/src/lib/stores/wallet.ts
+++ b/src/lib/stores/wallet.ts
@@ -33,7 +33,6 @@ export const createStore = async ({ rpcUrl, networkType, dappName}: {
 		});
 
 		Tezos.setWalletProvider(beacon);
-		subscribeToHead();
 		
 		network.set(networkType);
 		rpc.set(rpcUrl);

--- a/src/lib/stores/wallet.ts
+++ b/src/lib/stores/wallet.ts
@@ -33,7 +33,12 @@ export const createStore = async ({ rpcUrl, networkType, dappName}: {
 		});
 
 		Tezos.setWalletProvider(beacon);
-		
+
+		const activeAccount = await getActiveAccount();
+		if (activeAccount) {
+			setUserAddress(activeAccount.address);
+		}
+
 		network.set(networkType);
 		rpc.set(rpcUrl);
 	} catch (e) {
@@ -44,7 +49,7 @@ export const createStore = async ({ rpcUrl, networkType, dappName}: {
 export const connect = async () => {
 	try {
 		const activeAccount = await getActiveAccount();
-		if(!activeAccount) {
+		if (!activeAccount) {
 			await watchAccountPermissionRequest();
 		} else {
 			setUserAddress(activeAccount.address)


### PR DESCRIPTION
# remove subscription when createStore is called

in the first verison of `svelte-tezos` the `subscribeToHead()` function was called as the store was initialized. this is not useful in most use cases, so it has been removed.

this PR also sneaks in some small changes and improvements:
1. sets active account when store is created.
    - no longer relies on connect() being called to pull previous connection
2. adds MIT license to package.json