### PR TITLE
feat: set connected and loading accordingly if active acc detected

### DIFF
--- a/src/lib/stores/wallet.ts
+++ b/src/lib/stores/wallet.ts
@@ -37,6 +37,8 @@ export const createStore = async ({ rpcUrl, networkType, dappName}: {
 		const activeAccount = await getActiveAccount();
 		if (activeAccount) {
 			setUserAddress(activeAccount.address);
+			connected.set(true);
+			loading.set(false);
 		}
 
 		network.set(networkType);


### PR DESCRIPTION
# set connected and loading accordingly if active acc detected

this PR fixes an issue introduced in #2 where the connected and loading values were not updated if an active account was detected